### PR TITLE
fix: use pre python 3.10 syntax

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional
+from typing import Dict, Optional, Union
 from datetime import datetime
 from http import HTTPStatus
 from urllib.parse import urlparse, quote
@@ -18,7 +18,7 @@ from .crud import create_ticket, get_competition, get_ticket
 from .models import LnurlpParameters
 
 # Similar to /api/v1/lnurlscan/{code}
-async def get_lnurlp_parameters(code: str) -> LnurlpParameters | str:
+async def get_lnurlp_parameters(code: str) -> Union[LnurlpParameters, str]:
     try:
         url = lnurl.decode(code)
     except:


### PR DESCRIPTION
Small bug that block installation on environment with Python < 3.10

![image](https://github.com/oren-z0/bets4sats/assets/2951406/ead5e6f5-8a0c-4744-b640-6d3e32d3ee18)
